### PR TITLE
Desef style

### DIFF
--- a/desef/base.sty
+++ b/desef/base.sty
@@ -1,0 +1,212 @@
+\usepackage{etex}
+\usepackage{lmodern,amssymb,amsmath,fourier,microtype,setspace,calc,pgfmorepages,zref-user,zref-savepos,tikz,xifthen,xstring}
+
+\ifdefined\globalSpacing\relax\else\def\globalSpacing{1.3}\fi
+\ifdefined\hideNotes\relax\else\def\hideNotes{0}\fi
+
+% Setting up the twoside presentation
+\newcounter{dupnext}
+\pgfpagesdeclarelayout{dn}{}{
+   \pgfpagesphysicalpageoptions{%
+      logical pages=2,%
+      physical height=\pgfpageoptiontwoheight,%
+      physical width=\pgfpageoptiontwowidth,%
+      last logical shipout=1%
+   }
+   \pgfpageslogicalpageoptions{1}{%
+      center=\pgfpageoptionfirstcenter,%
+   }%
+   \pgfpageslogicalpageoptions{2}{%
+      center=\pgfpageoptionsecondcenter,%
+      skip code={{%
+         \hbadness=10000%
+         \vbadness=10000%
+         \ifthenelse{\value{dupnext}>0}{%
+            \ifvoid\csname pgfpages@box@1\endcsname\else%
+            \setbox\csname pgfpages@box@2\endcsname=%
+            \hbox to \pgfphysicalwidth{%
+               \hskip-.6in%
+               \vbadness=10000
+               \vbox to \pgfphysicalheight{%
+                  \vskip-1in%
+                  \parbox[l][0pt][t]{0pt}{%
+                     \hfuzz=\maxdimen%
+                     \vskip-\pgfphysicalheight%
+                     \vskip3mm%
+                     \parbox{2.5cm}{% Add an information that the next slide is shown
+                        \hskip-2mm%
+                        \textcolor{red}{Next slide}%
+                     }%
+                  }%
+                  \copy\beamer@frameboxcopy%
+               }%
+            }\fi%
+            \ifthenelse{\value{dupnext}=2}{%
+               \setcounter{dupnext}{0}%
+            }{%
+               \ifthenelse{\value{dupnext}>2}{%
+                  \addtocounter{dupnext}{-1}%
+               }{}%
+            }%
+         }{%
+            \setcounter{dupnext}{-\value{dupnext}}%
+         }%
+      }},%
+   }%
+}
+\newenvironment{peek}{%
+   \setcounter{dupnext}{-1}%
+}{%
+   \setcounter{dupnext}{0}%
+}
+\newcommand{\peeknext}[1][1]{%
+   \ifthenelse{#1=-1}{%
+      \setcounter{dupnext}{-1}%
+   }{%
+      \setcounter{dupnext}{-#1-1}%
+   }%
+}
+\newcommand{\stoppeek}{%
+   \setcounter{dupnext}{0}%
+}
+\setbeamertemplate{note page}[plain]
+\if\hideNotes1
+   \setbeameroption{hide notes}
+\else
+   \pgfpagesuselayout{dn}[second right]
+   \beamer@twoscreensnotestrue
+   \beamer@notestrue
+   \newcounter{pageanchored}
+   \def\Hy@EveryPageAnchor{%
+      \ifthenelse{\value{pageanchored}<\the\c@page}{% Don't insert twice
+         \Hy@DistillerDestFix
+         \vbox to 0pt{%
+            \kern\voffset
+            \kern\topmargin
+            \kern-1bp\relax
+            \hbox to 0pt{%
+               \kern\hoffset
+               \kern\oddsidemargin
+               \kern-1bp\relax
+               \hyper@@anchor{Navigation\the\c@page}\relax%
+               \hyper@@anchor{page.\the\c@page}\relax%
+               \hss
+            }%
+            \vss
+         }%
+         \setcounter{pageanchored}{\the\c@page}%
+      }{}
+   }
+\fi
+
+% Add spacing to every slide
+\let\oldbegin\beamer@framenotesbegin
+\def\beamer@framenotesbegin{\setstretch{\globalSpacing}\oldbegin}
+
+% Add indention capability to navigation for subsections
+\newlength{\sAw}
+\newlength{\sfl}
+\newcommand{\isec}[3]{% #1: Split char, #2: String to insert, #3: Beamer class
+   \StrCut{#2}{#1}{\sA}{\sB}%
+   \ifthenelse{\equal{\sB}{}}{% \isempty does not work
+      \beamer@sidebarformat{5pt}{#3}{%
+         \sA%
+      }%
+   }{%
+      \setlength{\sfl}{5pt}%
+      \settowidth{\sAw}{\sA#1}%
+      \addtolength{\sfl}{\sAw}%
+      \beamer@sidebarformat{\sfl}{#3}{%
+         \hspace{-\sAw}%
+         \sA#1\sB%
+      }%
+   }%
+}
+
+% Replace note command by the special, aligning one with hyperlink support
+\let\oldnote\note
+\if\hideNotes1
+   \AtBeginNote{%
+      \setstretch{\globalSpacing}%
+   }
+   \renewcommand<>{\note}[1]{%
+      \only#2{%
+         \vbox to 0pt{}% Same spacing as with notes
+      }%
+   }
+\else
+   \newcounter{pposes}
+   \newcounter{poses}
+   \AtBeginNote{%
+      \setcounter{poses}{0}%
+      \setstretch{\globalSpacing}%
+      \let\hyper@link@\hyper@link@note
+   }
+   \AtEndNote{%
+      \setcounter{poses}{0}%
+      \stepcounter{pposes}%
+      \let\hyper@link@\hyper@link@default
+   }
+   \renewcommand<>{\note}[1]{%
+      \only#2{%
+         \stepcounter{poses}%
+         \vbox to 0pt{%
+            \edef\l{p\the\value{pposes}-\the\value{poses}}%
+            \zsaveposy{\l}%
+            \zrefused{\l}%
+            \oldnote{%
+               \stepcounter{poses}%
+               \edef\l{p\the\value{pposes}-\the\value{poses}}%
+               \zref@ifrefundefined{\l}{}{%
+                  \parbox[l][0pt][t]{0pt}{%
+                     \hfuzz=\maxdimen%
+                     \parbox{\textwidth}{%
+                        \vspace{\dimexpr\paperheight - \zposy{\l}sp - 6mm}%
+                        #1%
+                     }%
+                  }%
+               }%
+            }%
+         }%
+      }%
+   }
+   \let\hyper@link@default\hyper@link@
+   \newcommand\hyper@link@note[4][]{%
+      \begingroup%
+         \parbox[l][0pt][t]{0pt}{%
+            \hfuzz=\maxdimen%
+            \vspace*{-1.5mm}%
+            \hspace*{\paperwidth}%
+            \hyper@link@default[#1]{#2}{#3}{\phantom{#4}}%
+         }%
+         \color{blue}#4%
+      \endgroup%
+   }
+\fi
+\newcommand<>{\Note}[1]{%
+   \vspace{-\baselineskip}%
+   \note#2{#1}%
+}
+\newcommand<>{\secEnd}[1][]{%
+   \only#2{\oldnote{%
+      \parbox[l][0pt][t]{0pt}{%
+         \hfuzz=\maxdimen%
+         \parbox{\textwidth}{%
+            \hfuzz=\maxdimen%
+            \vspace{\dimexpr\paperheight - 2.35cm}%
+            \hspace{\dimexpr\paperwidth - 3cm}%
+            \begin{tikzpicture}[baseline=(current bounding box.south)]
+               \draw (0, 0) -- (2, 2)
+                     (.05, 0) -- (2, 1.95)
+                     (.1, 0) -- (2, 1.9);
+               \begin{pgfinterruptboundingbox}
+                  \node[rotate=45, anchor=north, align=center] at (1, .95) {#1};
+               \end{pgfinterruptboundingbox}
+            \end{tikzpicture}
+         }%
+      }%
+   }}%
+}
+
+% Set some cosmetics defaults
+\ifdefined\themeOptions\relax\else\def\themeOptions{hideothersubsections}\fi

--- a/desef/cosmetics.sty
+++ b/desef/cosmetics.sty
@@ -1,0 +1,65 @@
+% Set PDF information
+\hypersetup{
+   pdfstartview={Fit},
+   pdftitle={\@title},
+   pdfauthor={\@author},
+   hidelinks,
+   breaklinks=false,
+}
+
+% Fix bad bracket size in Fourier
+\renewcommand{\big}{\bBigg@{1}}
+\renewcommand{\Big}{\bBigg@{1.5}}
+\renewcommand{\bigg}{\bBigg@{2.4}}
+\renewcommand{\Bigg}{\bBigg@{3.2}}
+% Replace bad Fourier arrows by those in Latin Modern
+\DeclareSymbolFont{lmsymbols}{OMS}{lmsy}{m}{n}
+\DeclareMathSymbol{\Leftarrow}{\mathrel}{lmsymbols}{40}
+\DeclareMathSymbol{\Rightarrow}{\mathrel}{lmsymbols}{41}
+\DeclareMathSymbol{\Leftrightarrow}{\mathrel}{lmsymbols}{44}
+
+% Other presentation settings
+\usetheme[width=1.95cm, \themeOptions]{Hannover}
+\usefonttheme[onlymath]{serif}
+\setbeamercolor*{section in sidebar shaded}{parent=palette sidebar secondary}
+\setbeamercolor*{section in sidebar}
+  {parent=section in sidebar shaded,use={sidebar,section in sidebar shaded},%
+   bg=sidebar.bg!70!section in sidebar shaded.fg}
+\setbeamercolor*{subsection in sidebar shaded}{parent=palette sidebar primary}
+\setbeamercolor*{subsection in sidebar}
+  {parent=subsection in sidebar shaded,use=section in sidebar,%
+   bg=section in sidebar.bg}
+\beamertemplatedotitem
+\setbeamertemplate{frametitle}[default][left]
+\setbeamertemplate{navigation symbols}{}
+\setbeamertemplate{itemize subitem}[triangle]
+\setbeamertemplate{itemize subsubitem}[ball]
+
+% Indent sections
+\newcommand{\indentSection}[1]{
+   \setbeamertemplate{section in sidebar}{%
+      \isec{#1}{\insertsectionhead}{section in sidebar}%
+   }
+   \setbeamertemplate{section in sidebar shaded}{%
+      \isec{#1}{\insertsectionhead}{section in sidebar shaded}%
+   }
+}
+\newcommand{\indentSubsection}[1]{
+   \setbeamertemplate{subsection in sidebar}{%
+      \isec{#1}{\insertsubsectionhead}{subsection in sidebar}%
+   }
+   \setbeamertemplate{subsection in sidebar shaded}{%
+      \isec{#1}{\insertsubsectionhead}{subsection in sidebar shaded}%
+   }
+}
+\newcommand{\indentSubsubsection}[1]{
+   \setbeamertemplate{subsubsection in sidebar}{%
+      \isec{#1}{\insertsubsubsectionhead}{subsubsection in sidebar}%
+   }
+   \setbeamertemplate{subsubsection in sidebar shaded}{%
+      \isec{#1}{\insertsubsubsectionhead}{subsubsection in sidebar shaded}%
+   }
+}
+
+% Math mode line spacing
+\setlength{\jot}{2mm}

--- a/desef/main.tex
+++ b/desef/main.tex
@@ -1,0 +1,224 @@
+\documentclass{beamer}
+
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+
+\title{Greek Alphabet}
+\subtitle{Demonstration presentation for usage with dspdfviewer}
+\author{Benjamin Desef}
+\date{11.08.2015}
+
+\makeatletter
+
+% The presentation and the notes will get a line stretch of this value
+% Default is 1.3.
+\def\globalSpacing{1.3}
+
+% You may use the \themeoptions macro to append options to the Hannover theme.
+% Default is hideothersubsections.
+%\def\themeOptions{}
+
+% This will control whether notes are suppressed (1) or not (0)
+% Default is 0.
+%\def\hideNotes{1}
+
+\input{base.sty}
+\input{cosmetics.sty}
+
+% Use those commands to define whether the navigation titels contain enumeration items.
+% For those, indention is controlled so they are aligned properly. The commands expect
+% the delimiter as a first parameter.
+%\indentSection{ }
+\indentSubsection{ }
+%\indentSubsubsection{ }
+
+\makeatother
+
+\begin{document}
+   \maketitle
+   \section{Majuscules}
+      \subsection{§1 First eight capital Greek letters}
+         \begin{frame}{Capital letters}{First eight}
+            \begin{enumerate}
+               \item Alpha, Beta
+               \item Gamma, Delta
+                  \note{This is an annotation that belongs to ``Gamma, Delta''.}
+               \item Epsilon, Zeta
+               \item Eta, Theta
+            \end{enumerate}
+         \end{frame}
+         \subsubsection{Alpha, Beta}
+            \begin{frame}{Capital letters}{Alpha, Beta}
+               \[ A \note{Annotations will always be inserted at the same $y$ position as the text they belong to. Insertion into math mode is also possible (align environments as well as \texttt{\textbackslash[ \textbackslash]}).} \]
+               \[ B \]
+            \end{frame}
+         \subsubsection{Gamma, Delta}
+            \begin{frame}{Capital letters}{Gamma, Delta}%
+               % The capital \Note command is needed, as \note will start a new paragraph. If no text follows, this leads to a wrong y position of the equations. I have not found a way to avoid this; basically, as soon as \pdfsavepos is triggered (here by \zsaveposy), the paragraph will begin. \Note compensates this by inserting a negative \vspace (undesirable if text follows).
+               \Note{Note that in the navigation bar, the long title of this subsection is adjusted in a way that the enumeration is aligned properly. For this purpose, the caption is split at a defined delimiter (which can easily be adjusted via the parameter of the \texttt{\textbackslash indent[Sub[Sub]]Section} command, see lines 31\,--\,33). This behavior is currently implemented for subsections, but can easily be extended to sections and subsubsections.}
+               \[ \Gamma \]
+               \[ \Delta \]
+            \end{frame}
+         \subsubsection{Epsilon, Zeta}
+            \begin{frame}[label=ce]{Capital letters}{Epsilon, Zeta}
+               \[ E \note{Jump to \hyperlink{se}{small epsilon} -- hyperlinks work in annotations as well.} \]
+               \[ Z \]
+            \end{frame}
+         \subsubsection{Eta, Theta}
+            \begin{frame}{Capital letters}{Eta, Theta}
+               \[ H \note{The next slide will show a preview of the following slide in the internal area. This can be done by enclosing the frames in a \texttt{peek} environment (but it cannot be triggered on or of \emph{within} one frame). It works for overlays as well as for more than one frame. You should not make use of notes on slide which has this key.} \]
+               \[ \Theta \]
+            \end{frame}
+      \subsection{§2 Next eight capital Greek letters}
+         \begin{peek}
+            \begin{frame}{Capital letters}{Next eight}
+               \begin{enumerate}[<+>]
+                  \setbeamercovered{transparent=50}
+                  \item Iota, Kappa
+                  \item Lambda, Mu
+                  \item Nu, Xi
+                  \item Omicron, Pi
+               \end{enumerate}
+            \end{frame}
+         \end{peek}
+         \subsubsection{Iota, Kappa}
+            \begin{frame}{Capital letters}{Iota, Kappa}
+               \[ I \note{If you do only want to show the next slide on the right side, you can use \texttt{\textbackslash peeknext} before the frame that should contain the duplication. The macro accepts an optional parameter which should be a positive integer (default $1$) that indicates for how long this state should be kept. Set it to $-1$ for infinite peeking (which can be stopped with \texttt{\textbackslash stoppeek}). This is demonstrated in the next frame.} \]
+               \[ K \]
+            \end{frame}
+         \peeknext
+         \subsubsection{Lambda, Mu}
+            \begin{frame}{Capital letters}{Lambda, Mu}
+               \[ \Lambda \]
+               \[ M \]
+            \end{frame}
+         \subsubsection{Nu, Xi}
+            \begin{frame}{Capital letters}{Nu, Xi}
+               \[ N \note{Sometimes, you may find it useful to indicate the end of a specific section in your notes. You can use the command \texttt{\textbackslash secEnd} for this, which accepts an optional parameter for a text that can be added to the end mark. This is demonstrated in the next slide (look at the bottom right).} \]
+               \[ \Xi \]
+            \end{frame}
+         \subsubsection{Omicron, Pi}
+            \begin{frame}{Capital letters}{Omicron, Pi}
+               \[ O \]
+               \[ \Pi \]
+            \end{frame}
+            \secEnd[End of §2 \\ \scriptsize Next: §3]
+      \subsection{§3 Last eight capital Greek letters}
+         \begin{frame}{Capital letters}{Last eight}
+            \begin{enumerate}[<+->]
+               \item Rho, Sigma \note<1>{Notes can also be bound to overlays.}
+               \item Tau, Upsilon \note<2>{Those overlays can be specified directly at the note command: \texttt{\textbackslash note<1->\{...\}}.}
+               \item Phi, Chi \note<3>{But it is also possible to include nodes in outer overlay commands.}
+               \item Psi, Omega \note<4>{Just keep in mind that any of the commands that only remove the ink, but not the spacing (such as \texttt{\textbackslash uncover}) will have no effect on notes. Only commands such as \texttt{\textbackslash only} will work as expected.}
+            \end{enumerate}
+         \end{frame}
+         \subsubsection{Rho, Sigma}
+            \begin{frame}{Capital letters}{Rho, Sigma}
+               \[ P \]
+               \[ \Sigma \]
+               \secEnd[\tiny end of comments]
+            \end{frame}
+         \subsubsection{Tau, Upsilon}
+            \begin{frame}{Capital letters}{Tau, Upsilon}
+               \[ T \]
+               \[ \Upsilon \]
+            \end{frame}
+         \subsubsection{Phi, Chi}
+            \begin{frame}{Capital letters}{Phi, Chi}
+               \[ \Phi \]
+               \[ X \]
+            \end{frame}
+         \subsubsection{Psi, Omega}
+            \begin{frame}{Capital letters}{Psi, Omega}
+               \[ \Psi \]
+               \[ \Omega \]
+            \end{frame}
+   \section{Minuscules}
+      \subsection{§1 First eight Greek letters}
+         \begin{frame}{Small letters}{First eight}
+            \begin{enumerate}
+               \item Alpha, Beta
+               \item Gamma, Delta
+               \item Epsilon, Zeta
+               \item Eta, Theta
+            \end{enumerate}
+         \end{frame}
+         \subsubsection{Alpha, Beta}
+            \begin{frame}{Small letters}{Alpha, Beta}
+               \[ \alpha \]
+               \[ \beta \]
+            \end{frame}
+         \subsubsection{Gamma, Delta}
+            \begin{frame}{Small letters}{Gamma, Delta}
+               \[ \gamma \]
+               \[ \delta \]
+            \end{frame}
+         \subsubsection{Epsilon, Zeta}
+            \begin{frame}[label=se]{Small letters}{Epsilon, Zeta}
+               \[ \epsilon \quad \varepsilon \note{Back to \hyperlink{ce}{capital epsilon}.} \]
+               \[ \zeta \]
+            \end{frame}
+         \subsubsection{Eta, Theta}
+            \begin{frame}{Small letters}{Eta, Theta}
+               \[ \eta \]
+               \[ \theta \quad \vartheta \]
+            \end{frame}
+      \subsection{§2 Next eight Greek letters}
+         \begin{frame}{Small letters}{Next eight}
+            \begin{enumerate}
+               \item Iota, Kappa
+               \item Lambda, Mu
+               \item Nu, Xi
+               \item Omicron, Pi
+            \end{enumerate}
+         \end{frame}
+         \subsubsection{Iota, Kappa}
+            \begin{frame}{Small letters}{Iota, Kappa}
+               \[ \iota \]
+               \[ \kappa \]
+            \end{frame}
+         \subsubsection{Lambda, Mu}
+            \begin{frame}{Small letters}{Lambda, Mu}
+               \[ \lambda \]
+               \[ \mu \]
+            \end{frame}
+         \subsubsection{Nu, Xi}
+            \begin{frame}{Small letters}{Nu, Xi}
+               \[ \nu \]
+               \[ \xi \]
+            \end{frame}
+         \subsubsection{Omicron, Pi}
+            \begin{frame}{Small letters}{Omicron, Pi}
+               \[ o \]
+               \[ \pi \quad \varpi \]
+            \end{frame}
+      \subsection{§3 Last eight capital Greek letters}
+         \begin{frame}{Small letters}{Last eight}
+            \begin{enumerate}
+               \item Rho, Sigma
+               \item Tau, Upsilon
+               \item Phi, Chi
+               \item Psi, Omega
+            \end{enumerate}
+         \end{frame}
+         \subsubsection{Rho, Sigma}
+            \begin{frame}{Small letters}{Rho, Sigma}
+               \[ \rho \quad \varrho \]
+               \[ \sigma \quad \varsigma \]
+            \end{frame}
+         \subsubsection{Tau, Upsilon}
+            \begin{frame}{Small letters}{Tau, Upsilon}
+               \[ \tau \]
+               \[ \upsilon \]
+            \end{frame}
+         \subsubsection{Phi, Chi}
+            \begin{frame}{Small letters}{Phi, Chi}
+               \[ \phi \quad \varphi \]
+               \[ \chi \]
+            \end{frame}
+         \subsubsection{Psi, Omega}
+            \begin{frame}{Small letters}{Psi, Omega}
+               \[ \psi \]
+               \[ \omega \]
+            \end{frame}
+\end{document}

--- a/desef/pgfmorepages.sty
+++ b/desef/pgfmorepages.sty
@@ -1,0 +1,1620 @@
+% Original code copyright 2006 by Till Tantau
+% Extension copyright 2012 by Andrew Stacey
+%
+% This file may be distributed and/or modified
+%
+% 1. under the LaTeX Project Public License and/or
+% 2. under the GNU Public License.
+%
+% See the file doc/generic/pgf/licenses/LICENSE for more details.
+
+\ProvidesPackage{pgfmorepages}[2012/06/07 ver 0.01]
+
+\@ifpackageloaded{pgfpages}{%
+  \PackageWarning{pgfmorepages}{I notice that the package "pgfpages" has already been loaded.  This is an extension of that package and redefines various internal pieces so the two should not be used together.}
+}{}
+
+
+\RequirePackage{pgfcore,calc}
+
+\newcount\pgf@logicalpages
+\newcount\pgf@physicalpages
+\newcount\pgf@firstshipout
+\newcount\pgf@lastshipout
+\newcount\pgf@currentshipout
+\newcount\pgf@cpn
+\newcount\pgf@clpn
+\newcount\pgf@cppn
+\newcount\pgfactualpage
+\newcount\pgf@shipoutnextto
+\newdimen\pgfphysicalheight
+\newdimen\pgfphysicalwidth
+\newif\ifpgfpagesship
+
+\pgf@shipoutnextto=0\relax
+\pgf@logicalpages=0\relax
+\pgf@physicalpages=1\relax
+\pgf@firstshipout=1\relax
+\pgf@lastshipout=1\relax
+\pgf@currentshipout=1\relax
+\pgfphysicalheight=\paperheight
+\pgfphysicalwidth=\paperwidth
+\pgfactualpage=0
+\def\pgf@currentpage{1}
+
+\newif\ifpgfphysicalpageempty
+\newif\ifpgf@holdingphysicalpage
+
+\pgfphysicalpageemptytrue
+\pgf@holdingphysicalpagefalse
+
+
+% Define a layout
+%
+% #1 = layout name
+% #2 = code before options have been set
+% #2 = code after options have been set
+%
+% Example:
+%
+% \pgfpagesdeclarelayout{resize to}{
+%    \pgfpagesphysicalpageoptions{logical pages=1,physical height=\pgfpageoptionheight,physical width=\pgfpageoptionwidth}
+%    \pgfpageslogicalpageoptions{1}{resized width=\pgfphysicalwidth,%
+%      resized height=\pgfphysicalheight,center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}}}
+
+\newcommand\pgfpagesdeclarelayout[3]{
+  \expandafter\newcommand\csname pgfpages@layoutbefore@#1\endcsname{#2}
+  \expandafter\newcommand\csname pgfpages@layout@#1\endcsname{#3}}
+
+
+% Use a layout
+%
+% #1 = layout name
+% #2 = options
+%
+% Example:
+%
+% \pgfpagesuselayout{resize to}[a4paper]
+
+\def\pgfpagesuselayout#1{\pgfutil@ifnextchar[{\pgf@pagelayout{#1}}{\pgf@pagelayout{#1}[]}}
+\def\pgf@pagelayout#1[#2]{
+  \csname pgfpages@layoutbefore@#1\endcsname
+  \setkeys{pgfpagesuselayoutoption}{#2}
+  \pgfutil@ifundefined{pgfpages@layout@#1}{
+    \PackageError{pgfpages}{Page layout `#1' undefined.}{}
+  }
+  {
+    \csname pgfpages@layout@#1\endcsname
+  }
+}
+
+
+% Predefined options
+
+\define@key{pgfpagesuselayoutoption}{physical paper width}%
+{\def\pgfpageoptionwidth{#1}}
+
+\define@key{pgfpagesuselayoutoption}{physical paper height}%
+{\def\pgfpageoptionheight{#1}}
+
+\define@key{pgfpagesuselayoutoption}{a0paper}[]%
+{\def\pgfpageoptionheight{1189mm} \def\pgfpageoptionwidth{841mm}}
+
+\define@key{pgfpagesuselayoutoption}{a1paper}[]%
+{\def\pgfpageoptionheight{841mm} \def\pgfpageoptionwidth{594mm}}
+
+\define@key{pgfpagesuselayoutoption}{a2paper}[]%
+{\def\pgfpageoptionheight{594mm} \def\pgfpageoptionwidth{420mm}}
+
+\define@key{pgfpagesuselayoutoption}{a3paper}[]%
+{\def\pgfpageoptionheight{420mm} \def\pgfpageoptionwidth{297mm}}
+
+\define@key{pgfpagesuselayoutoption}{a4paper}[]%
+{\def\pgfpageoptionheight{297mm} \def\pgfpageoptionwidth{210mm}}
+
+\define@key{pgfpagesuselayoutoption}{a5paper}[]%
+{\def\pgfpageoptionheight{210mm} \def\pgfpageoptionwidth{148mm}}
+
+\define@key{pgfpagesuselayoutoption}{a6paper}[]%
+{\def\pgfpageoptionheight{148mm} \def\pgfpageoptionwidth{105mm}}
+
+\define@key{pgfpagesuselayoutoption}{letterpaper}[]%
+{\def\pgfpageoptionheight{11in}  \def\pgfpageoptionwidth{8.5in}}
+
+\define@key{pgfpagesuselayoutoption}{legalpaper}[]%
+{\def\pgfpageoptionheight{14in}  \def\pgfpageoptionwidth{8.5in}}
+
+\define@key{pgfpagesuselayoutoption}{executivepaper}[]%
+{\def\pgfpageoptionheight{10.5in}\def\pgfpageoptionwidth{7.25in}}
+
+\define@key{pgfpagesuselayoutoption}{landscape}[]%
+{
+  \let\pgf@temp=\pgfpageoptionwidth
+  \let\pgfpageoptionwidth=\pgfpageoptionheight
+  \let\pgfpageoptionheight=\pgf@temp
+}
+
+\define@key{pgfpagesuselayoutoption}{border shrink}%
+{\def\pgfpageoptionborder{#1}}
+
+\define@key{pgfpagesuselayoutoption}{corner width}%
+{\def\pgfpageoptioncornerwidth{#1}}
+
+\define@key{pgfpagesuselayoutoption}{odd numbered pages right}[]%
+{\def\pgfpageoptionfirstshipout{2}}
+
+\define@key{pgfpagesuselayoutoption}{second right}[]%
+{%
+  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpoint{1.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptiontwoheight{\paperheight}%
+  \def\pgfpageoptiontwowidth{2\paperwidth}%
+}
+
+\define@key{pgfpagesuselayoutoption}{second left}[]%
+{%
+  \def\pgfpageoptionfirstcenter{\pgfpoint{1.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptiontwoheight{\paperheight}%
+  \def\pgfpageoptiontwowidth{2\paperwidth}%
+}
+
+\define@key{pgfpagesuselayoutoption}{second top}[]%
+{%
+  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{1.5\paperheight}}%
+  \def\pgfpageoptiontwoheight{2\paperheight}%
+  \def\pgfpageoptiontwowidth{\paperwidth}%
+}
+
+\define@key{pgfpagesuselayoutoption}{second bottom}[]%
+{%
+  \def\pgfpageoptionfirstcenter{\pgfpoint{.5\paperwidth}{1.5\paperheight}}%
+  \def\pgfpageoptionsecondcenter{\pgfpoint{.5\paperwidth}{.5\paperheight}}%
+  \def\pgfpageoptiontwoheight{2\paperheight}%
+  \def\pgfpageoptiontwowidth{\paperwidth}%
+}
+
+
+
+% Predefined layouts
+
+\pgfpagesdeclarelayout{rounded corners}
+{
+  \def\pgfpageoptioncornerwidth{10pt}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=1
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight},%
+    corner width=\pgfpageoptioncornerwidth%
+  }%
+}
+
+\pgfpagesdeclarelayout{resize to}
+{
+  \def\pgfpageoptionborder{0pt}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=1,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth%
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    resized width=\pgfphysicalwidth,%
+    resized height=\pgfphysicalheight,%
+    border shrink=\pgfpageoptionborder,%
+    center=\pgfpoint{.5\pgfphysicalwidth}{.5\pgfphysicalheight}%
+  }%
+}
+
+\pgfpagesdeclarelayout{two screens with lagging second}
+{}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=2,%
+    physical height=\pgfpageoptiontwoheight,%
+    physical width=\pgfpageoptiontwowidth,%
+    last logical shipout=1,%
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    center=\pgfpageoptionfirstcenter,%
+  }%
+  \pgfpageslogicalpageoptions{2}
+  {%
+    center=\pgfpageoptionsecondcenter,%
+    copy from=1%
+  }%
+}
+
+\pgfpagesdeclarelayout{two screens with optional second}
+{}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=2,%
+    physical height=\pgfpageoptiontwoheight,%
+    physical width=\pgfpageoptiontwowidth,%
+    last logical shipout=1%
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    center=\pgfpageoptionfirstcenter,%
+  }%
+  \pgfpageslogicalpageoptions{2}
+  {%
+    center=\pgfpageoptionsecondcenter,%
+    copy from=2%
+  }%
+}
+
+\pgfpagesdeclarelayout{2 on 1}
+{
+  \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=2,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \else
+    % stack on top of one another
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \fi    
+}
+
+
+\pgfpagesdeclarelayout{4 on 1}
+{
+  \edef\pgfpageoptionheight{\the\paperheight} 
+  \edef\pgfpageoptionwidth{\the\paperwidth}
+  \edef\pgfpageoptionborder{0pt}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=4,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth%
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.5\pgfphysicalwidth,%
+    resized height=.5\pgfphysicalheight,%
+    center=\pgfpoint{.25\pgfphysicalwidth}{.75\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{2}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.5\pgfphysicalwidth,%
+    resized height=.5\pgfphysicalheight,%
+    center=\pgfpoint{.75\pgfphysicalwidth}{.75\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{3}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.5\pgfphysicalwidth,%
+    resized height=.5\pgfphysicalheight,%
+    center=\pgfpoint{.25\pgfphysicalwidth}{.25\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{4}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.5\pgfphysicalwidth,%
+    resized height=.5\pgfphysicalheight,%
+    center=\pgfpoint{.75\pgfphysicalwidth}{.25\pgfphysicalheight}%
+  }%
+}
+
+
+\pgfpagesdeclarelayout{8 on 1}
+{
+  \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=8,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth%
+  }
+  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.125\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.375\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.625\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.875\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{5}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.125\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{6}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.375\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{7}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.625\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{8}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.25\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.875\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \else
+    % stack on top of one another
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.875\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.625\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{5}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{6}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.375\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{7}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{8}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=.25\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.125\pgfphysicalheight}%
+    }%
+  \fi    
+}
+
+
+\pgfpagesdeclarelayout{16 on 1}
+{
+  \edef\pgfpageoptionheight{\the\paperheight} 
+  \edef\pgfpageoptionwidth{\the\paperwidth}
+  \edef\pgfpageoptionborder{0pt}
+}
+{
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=16,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth%
+  }
+  \pgfpageslogicalpageoptions{1}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.125\pgfphysicalwidth}{.875\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{2}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.375\pgfphysicalwidth}{.875\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{3}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.625\pgfphysicalwidth}{.875\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{4}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.875\pgfphysicalwidth}{.875\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{5}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.125\pgfphysicalwidth}{.625\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{6}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.375\pgfphysicalwidth}{.625\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{7}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.625\pgfphysicalwidth}{.625\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{8}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.875\pgfphysicalwidth}{.625\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{9}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.125\pgfphysicalwidth}{.375\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{10}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.375\pgfphysicalwidth}{.375\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{11}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.625\pgfphysicalwidth}{.375\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{12}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.875\pgfphysicalwidth}{.375\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{13}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.125\pgfphysicalwidth}{.125\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{14}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.375\pgfphysicalwidth}{.125\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{15}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.625\pgfphysicalwidth}{.125\pgfphysicalheight}%
+  }%
+  \pgfpageslogicalpageoptions{16}
+  {%
+    border shrink=\pgfpageoptionborder,%
+    resized width=.25\pgfphysicalwidth,%
+    resized height=.25\pgfphysicalheight,%
+    center=\pgfpoint{.875\pgfphysicalwidth}{.125\pgfphysicalheight}%
+  }%
+}
+
+\pgfpagesdeclarelayout{4 on 2, odd then even}%
+{%
+   \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=4,%
+    physical pages=2,%
+     physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \else
+    % stack on top of one another
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \fi    
+}
+
+\pgfpagesdeclarelayout{4 on 2, even then odd}%
+{%
+   \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=4,%
+    physical pages=2,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \else
+    % stack on top of one another
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \fi    
+}
+
+\pgfpagesdeclarelayout{4 on 2, book format}%
+{%
+   \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=4,%
+    physical pages=2,%
+     physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \else
+    % stack on top of one another
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.75\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=\pgfphysicalwidth,%
+      resized height=.5\pgfphysicalheight,%
+      center=\pgfpoint{.5\pgfphysicalwidth}{.25\pgfphysicalheight}%
+    }%
+  \fi    
+}
+
+\pgfpagesdeclarelayout{8 on 4, book format}%
+{%
+  \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=8,%
+    physical pages=4,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+%  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{8}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{7}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{3}{}
+    \pgfpageslogicalpageoptions{6}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{4}{}
+    \pgfpageslogicalpageoptions{5}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{3}{}
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+%  \else
+    % stack on top of one another
+%  \fi    
+}
+
+\pgfpagesdeclarelayout{8 on 4, book format, reverse second, single sided}%
+{%
+  \edef\pgfpageoptionheight{\the\paperwidth} % landscaped by default
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=8,%
+    physical pages=4,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+%  \ifdim\paperheight>\paperwidth\relax
+    % put side-by-side
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{8}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{1}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{4}{}
+    \pgfpageslogicalpageoptions{7}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight},%
+      rotation=180%
+    }%
+    \pgfpageslogicalpageoptions{2}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight},%
+      rotation=180%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{6}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight}%
+    }%
+  \pgfpagesphysicalpage{3}{}
+    \pgfpageslogicalpageoptions{5}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.25\pgfphysicalwidth}{.5\pgfphysicalheight},%
+      rotation=180%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      border shrink=\pgfpageoptionborder,%
+      resized width=.5\pgfphysicalwidth,%
+      resized height=\pgfphysicalheight,%
+      center=\pgfpoint{.75\pgfphysicalwidth}{.5\pgfphysicalheight},%
+      rotation=180%
+    }%
+%  \else
+    % stack on top of one another
+%  \fi    
+}
+
+
+\pgfpagesdeclarelayout{5 index cards}
+{%
+  \edef\pgfpageoptionheight{\the\paperwidth}
+  \edef\pgfpageoptionwidth{\the\paperheight}
+  \def\pgfpageoptionborder{0pt}
+  \def\pgfpageoptionfirstshipout{1}
+}%
+{%
+  \pgfpagesphysicalpageoptions
+  {%
+    logical pages=10,%
+    physical pages=2,%
+    physical height=\pgfpageoptionheight,%
+    physical width=\pgfpageoptionwidth,%
+    current logical shipout=\pgfpageoptionfirstshipout%
+  }
+  \pgfpagessetdefaults{%
+    border shrink=\pgfpageoptionborder,%
+    resized width=\the\paperwidth,%
+    resized height=\the\paperheight,%
+    border code=\pgfusepath{draw}
+  }
+  \pgfpagesphysicalpage{1}{}
+    \pgfpageslogicalpageoptions{1}
+    {%
+      center=\pgfpoint{.5\paperwidth}{.75*\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{3}
+    {%
+      center=\pgfpoint{.5\paperwidth}{.25*\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{5}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth + \paperwidth)}{\pgfphysicalheight - .5\paperheight},%
+    }%
+    \pgfpageslogicalpageoptions{7}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth + \paperwidth)}{.5\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{9}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth + \paperwidth)}{.5\paperheight},%
+    }%
+  \pgfpagesphysicalpage{2}{}
+    \pgfpageslogicalpageoptions{2}
+    {%
+      center=\pgfpoint{\pgfphysicalwidth - .5\paperwidth}{.75\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{4}
+    {%
+      center=\pgfpoint{\pgfphysicalwidth - .5\paperwidth}{.25\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{6}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth - \paperwidth)}{\pgfphysicalheight - .5\paperheight},%
+    }%
+    \pgfpageslogicalpageoptions{8}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth - \paperwidth)}{.5\pgfphysicalheight},%
+    }%
+    \pgfpageslogicalpageoptions{10}
+    {%
+      rotation=90,%
+      center=\pgfpoint{.5*(\pgfphysicalwidth - \paperwidth)}{.5\paperheight},%
+    }%
+}
+
+
+% Change/set main option
+%
+% #1 = options
+%
+% Options:
+%
+% logical pages     = number of logical pages per physical page
+% logical shipouts  = number of shipouts needed to fill a physical page
+%                     (may be less than the number of logical pages,
+%                     if some logical pages are calculated
+%                     automatically) 
+% current logical shipout = number of logical shipout that will come
+%                           next. 
+%
+% Example:
+%
+% \pgfpagesphysicalpageoptions{logical pages=2,logical shipouts=1}
+
+\newcommand\pgfpagesphysicalpageoptions[1]{%
+  \pgf@lastshipout=0\relax%
+  \pgf@currentshipout=0\relax%
+  \setkeys{pgfpages@main}{#1}%
+  \ifnum\pgf@lastshipout=0\relax%not set
+    \pgf@lastshipout=\pgf@logicalpages%
+  \fi%  
+  \ifnum\pgf@currentshipout=0\relax%not set
+    \pgf@currentshipout=\pgf@firstshipout%
+  \fi%  
+}
+
+\define@key{pgfpages@main}{logical pages}{\pgf@logicalpages=#1\relax}
+\define@key{pgfpages@main}{physical pages}{\pgf@physicalpages=#1\relax}
+\define@key{pgfpages@main}{first logical shipout}{\pgf@firstshipout=#1\relax}
+\define@key{pgfpages@main}{last logical shipout}{\pgf@lastshipout=#1\relax}
+\define@key{pgfpages@main}{current logical shipout}{\pgf@currentshipout=#1\relax}
+\define@key{pgfpages@main}{physical height}{\pgfphysicalheight=#1\relax}
+\define@key{pgfpages@main}{physical width}{\pgfphysicalwidth=#1\relax}
+
+
+
+% Setup/change parameters of a logical page. You must call this
+% macro for each logical page.
+%
+% #1 = logical page number
+% #2 = options
+%
+% Options:
+%
+% original height = height of the logical page (\paperheight at point of
+%                   first invocation by default) 
+% original width  = width of the logical page (\paperwidth by default)
+% resized height  = height of the logical page after resizing
+% resized width   = width of the logical page after resizing
+% border shrink   = length that is subtracted from resized height and
+%                   resized width
+% border code     = pgf commands to be used for drawing a border (a
+%                   path with the border set will already have been
+%                   set) 
+% rounded corners = clip the frame against a rectangle of the size of
+%                   the frame with corners of the given radius
+% scale           = factor by which the page is enlarged/shrunk 
+% center          = center of the logical page in the physical page
+% rotation        = degree by which the page is rotated around its center
+% xscale          = scale only x-axis (use -1 to flip along y-axis)
+% yscale          = scale only y-axis (use -1 to flip along x-axis)
+% copy from       = copy the contents from this logical page of the
+%                   previous physical page, if no contents is specified 
+%
+% If more than one of the three options ``resized height'', ``resized
+% width'' and ``scale'' are given, the smallest resulting scaling
+% wins. 
+%
+% Example:
+%
+% \pgfpageslogicalpageoptions{1}{scale=0.5,center=\pgfpoint{0cm}{2cm}}
+% \pgfpageslogicalpageoptions{1 on 2}{scale=0.5,center=\pgfpoint{0cm}{2cm}}
+
+\newcommand\pgfpageslogicalpageoptions[2]{%
+% First step is to work out which physical page and which logical page we're dealing with.
+% This could be set via the first argument if it is of the form ``x on y'': this means ``logical page x on physical page y''.
+% Or we could set the physical page beforehand via the \pgfpagesphysicalpage macro.
+  \pgfutil@in@{on}{#1}%
+  \ifpgfutil@in@
+  \pgf@mp@seplp#1\relax
+  \else
+  \pgf@clpn=#1\relax%
+  \pgf@cppn=\pgf@currentpage\relax%
+  \fi
+% Make sure we have the box for this logical page.
+  \expandafter\ifx\csname pgfpages@box@\the\pgf@clpn\endcsname\relax%
+    \expandafter\newbox\csname pgfpages@box@\the\pgf@clpn\endcsname%
+\pgf@elpsetcurrent{height}{\the\paperheight}%
+\pgf@elpsetcurrent{width}{\the\paperwidth}%
+\fi
+% Now set the count \pgf@cpn so that it is the number of logical pages on this particular physical page.
+      \expandafter\ifx\csname pgf@lpageson@\the\pgf@cppn\endcsname\relax
+\expandafter\def\csname pgf@lpageson@\the\pgf@cppn\endcsname{1}%
+\else
+\expandafter\edef\csname pgf@lpageson@\the\pgf@cppn\endcsname{\number\numexpr\csname pgf@lpageson@\the\pgf@cppn\endcsname + 1\relax}%
+\fi
+      \pgf@cpn=\numexpr\csname pgf@lpageson@\the\pgf@cppn\endcsname\relax
+\pgf@epsetcurrent{logicalpage}{\the\pgf@clpn}%
+\pgfpages@processdefaults
+  \setkeys{pgfpages@page}{#2}%
+  \pgf@calculateresizes{height}%
+  \pgf@calculateresizes{width}%
+  \pgfsetupphysicalpagesizes%
+}
+
+\def\pgf@mp@seplp#1on#2\relax{%
+  \pgf@cpn=#1\relax
+  \pgf@cppn=#2\relax
+}
+
+% Set the current default physical page for the logical page options
+\newcommand\pgfpagesphysicalpage[2]{%
+      \edef\pgf@currentpage{#1}%
+      \pgf@cppn=#1\relax
+      \setkeys{pgfpages@ppage}{#2}%
+}
+
+% Set some defaults
+\newcommand\pgfpagessetdefaults[1]{%
+      \def\pgf@defaults{#1}}
+\def\pgf@defaults{}
+
+\def\pgfpages@processdefaults{%
+      \def\pgf@temp{\setkeys{pgfpages@page}}%
+      \expandafter\pgf@temp\expandafter{\pgf@defaults}%
+}
+
+% Set and get options for a particular logical page on a particular physical page.
+\def\pgf@epset#1#2#3#4{\expandafter\edef\csname pgfpages@p@#1@#2@#3\endcsname{#4}}
+\def\pgf@pset#1#2#3#4{\expandafter\def\csname pgfpages@p@#1@#2@#3\endcsname{#4}}
+\def\pgf@pget#1#2#3{\csname pgfpages@p@#1@#2@#3\endcsname}
+\def\pgf@epsetcurrent#1#2{\pgf@epset{\the\pgf@cpn}{\the\pgf@cppn}{#1}{#2}}
+\def\pgf@psetcurrent#1#2{\pgf@pset{\the\pgf@cpn}{\the\pgf@cppn}{#1}{#2}}
+\def\pgf@pgetcurrent#1{\pgf@pget{\the\pgf@cpn}{\the\pgf@cppn}{#1}}
+
+% Set and get options for a particular logical page.
+\def\pgf@elpset#1#2#3{\expandafter\edef\csname pgfpages@lp@#1@#2\endcsname{#3}}
+\def\pgf@lpset#1#2#3{\expandafter\def\csname pgfpages@lp@#1@#2\endcsname{#3}}
+\def\pgf@lpget#1#2{\csname pgfpages@lp@#1@#2\endcsname}
+\def\pgf@elpsetcurrent#1#2{\pgf@elpset{\the\pgf@clpn}{#1}{#2}}
+\def\pgf@lpsetcurrent#1#2{\pgf@lpset{\the\pgf@clpn}{#1}{#2}}
+\def\pgf@lpgetcurrent#1{\pgf@lpget{\the\pgf@clpn}{#1}}
+
+% Set and get options for a particular physical page.
+\def\pgf@eppset#1#2#3{\expandafter\edef\csname pgfpages@pp@#1@#2\endcsname{#3}}
+\def\pgf@ppset#1#2#3{\expandafter\def\csname pgfpages@pp@#1@#2\endcsname{#3}}
+\def\pgf@ppget#1#2{\csname pgfpages@pp@#1@#2\endcsname}
+\def\pgf@eppsetcurrent#1#2{\pgf@eppset{\the\pgf@cppn}{#1}{#2}}
+\def\pgf@ppsetcurrent#1#2{\pgf@ppset{\the\pgf@cppn}{#1}{#2}}
+\def\pgf@ppgetcurrent#1{\pgf@ppget{\the\pgf@cppn}{#1}}
+
+\define@key{pgfpages@page}{skip code}{\pgf@psetcurrent{skipcode}{#1}}
+\define@key{pgfpages@page}{scale}{\pgf@epsetcurrent{scale}{#1}}
+\define@key{pgfpages@page}{xscale}{\pgf@epsetcurrent{xscale}{#1}}
+\define@key{pgfpages@page}{yscale}{\pgf@epsetcurrent{yscale}{#1}}
+\define@key{pgfpages@page}{original height}{\pgf@elpsetcurrent{height}{#1}}
+\define@key{pgfpages@page}{original width}{\pgf@elpsetcurrent{width}{#1}}
+\define@key{pgfpages@page}{resized height}{\pgf@epsetcurrent{reheight}{#1}}
+\define@key{pgfpages@page}{resized width}{\pgf@epsetcurrent{rewidth}{#1}}
+\define@key{pgfpages@page}{center}{\pgf@psetcurrent{center}{#1}}
+\define@key{pgfpages@page}{rotation}{\pgf@epsetcurrent{rotation}{#1}}
+\define@key{pgfpages@page}{copy from}{\pgf@elpsetcurrent{copy}{#1}}
+\define@key{pgfpages@page}{border shrink}{\pgf@epsetcurrent{border}{#1}}
+\define@key{pgfpages@page}{border code}{\pgf@psetcurrent{bordercode}{#1}}
+\define@key{pgfpages@page}{corner width}{\pgf@psetcurrent{cornerwidth}{#1}}
+
+\define@key{pgfpages@ppage}{skip code}{\pgf@ppsetcurrent{skipcode}{#1}}
+\define@key{pgfpages@ppage}{defaults}{\pgfpagessetdefaults{#1}}
+
+\def\pgf@calculateresizes#1{%
+  \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @re#1\endcsname\relax%
+  \else%
+    \expandafter\pgfutil@tempdima\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @re#1\endcsname\relax%
+    \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @border\endcsname\relax%
+    \else%
+      \expandafter\pgfutil@tempdimb\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @border\endcsname\relax%
+      \advance\pgfutil@tempdima by-2\pgfutil@tempdimb\relax%
+    \fi%
+    \expandafter\pgfutil@tempdimb\csname pgfpages@lp@\the\pgf@clpn @#1\endcsname\relax%
+    \pgfutil@tempcnta=\pgfutil@tempdimb%
+    \divide\pgfutil@tempcnta by 65536\relax%
+    \ifnum\pgfutil@tempcnta=0\relax%
+      \pgfutil@tempcnta=1\relax%
+    \fi%
+    \divide\pgfutil@tempdima by\pgfutil@tempcnta\relax%
+    \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @scale\endcsname\relax%
+      \pgfutil@tempdimb=10000pt%
+    \else%
+      \expandafter\pgfutil@tempdimb\expandafter=\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @scale\endcsname pt\relax%
+    \fi%
+    \ifdim\pgfutil@tempdima<\pgfutil@tempdimb%
+      \edef\pgf@temp{{scale}{\expandafter\Pgf@geT\the\pgfutil@tempdima}}%
+      \expandafter\pgf@psetcurrent\pgf@temp%
+    \fi%
+  \fi%
+}
+
+
+
+% Shipout a physical page immediately
+%
+% Example:
+%
+% \pgfshipoutphysicalpage
+
+
+\newcommand\pgfshipoutphysicalpage{%
+  \ifnum\pgf@logicalpages>0\relax%
+  \pgf@cppn=1\relax%
+  \loop%
+  \global\advance\pgfactualpage by 1\relax
+      \pgfpagesshiptrue
+  \csname pgfpages@pp@\the\pgf@cppn @skipcode\endcsname
+      \ifpgfpagesship
+    \pgfpages@buildshipoutbox%
+    \pgfpages@shipoutshipoutbox%
+      \fi
+  \ifnum\pgf@cppn<\pgf@physicalpages%
+  \advance \pgf@cppn by 1\relax
+  \repeat%
+    \pgfpages@performcopying%
+    \global\pgfphysicalpageemptytrue%
+    \global\pgf@holdingphysicalpagefalse%  
+  \fi%
+}
+
+\newbox\pgfpages@shipoutbox
+
+\def\pgfpages@buildshipoutbox{%
+  \setbox\pgfpages@shipoutbox=\vbox{{%
+    \set@typeset@protect%
+    \offinterlineskip%
+    \pgfsys@beginpicture%
+    \pgf@cpn=1\relax%
+    \loop%
+      \pgfpagesshiptrue
+          \csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @skipcode\endcsname
+\ifpgfpagesship
+\pgf@clpn=\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @logicalpage\endcsname\relax%
+      \setbox0=\hbox to \csname pgfpages@lp@\the\pgf@clpn @width\endcsname{%
+        \hskip1in%
+        \vbox to \csname pgfpages@lp@\the\pgf@clpn @height\endcsname%
+          {\vskip1in\offinterlineskip\expandafter\copy\csname
+            pgfpages@box@\the\pgf@clpn\endcsname\vss}\hss}%
+      \pgfsys@beginscope%
+        % Translate lower left corner
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @center\endcsname\relax%
+        \else%
+          \pgflowlevel{\pgftransformshift{\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @center\endcsname}}%
+        \fi%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @scale\endcsname\relax%
+        \else%
+          \pgflowlevel{\pgftransformscale{\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @scale\endcsname}}%
+        \fi%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @xscale\endcsname\relax%
+        \else%
+          \pgflowlevel{\pgftransformxscale{\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @xscale\endcsname}{1}}%
+        \fi%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @yscale\endcsname\relax%
+        \else%
+          \pgflowlevel{\pgftransformyscale{\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @yscale\endcsname}}%
+        \fi%
+        \pgfscope%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @rotation\endcsname\relax%
+        \else%
+          \pgflowlevel{\pgftransformrotate{\csname
+              pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @rotation\endcsname}}%
+        \fi%
+        \pgfutil@tempdima=\csname pgfpages@lp@\the\pgf@clpn @width\endcsname\relax%
+        \pgfutil@tempdimb=\csname pgfpages@lp@\the\pgf@clpn @height\endcsname\relax%
+        \pgflowlevel{\pgftransformshift{\pgfpoint{-.5\pgfutil@tempdima}{-.5\pgfutil@tempdimb}}}%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @bordercode\endcsname\relax%
+        \else%
+          \pgfpathmoveto{\pgfpointorigin}%
+          \pgfpathlineto{\pgfpoint{\wd0}{0pt}}%
+          \pgfpathlineto{\pgfpoint{\wd0}{\ht0}}%
+          \pgfpathlineto{\pgfpoint{0pt}{\ht0}}%
+          \pgfpathclose%
+          {\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @bordercode\endcsname}%
+        \fi%
+        \expandafter\ifx\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @cornerwidth\endcsname\relax%
+        \else%
+          {
+            \expandafter\pgfutil@tempdima\csname pgfpages@p@\the\pgf@cpn @\the\pgf@cppn @cornerwidth\endcsname\relax%
+            \color{black}
+            \pgfpathrectangle{\pgfpointorigin}{\pgfpoint{\pgfutil@tempdima}{\pgfutil@tempdima}}%
+            \pgfpathrectangle{\pgfpoint{0pt}{\ht0-\pgfutil@tempdima}}{\pgfpoint{\pgfutil@tempdima}{\pgfutil@tempdima}}%
+            \pgfpathrectangle{\pgfpoint{\wd0-\pgfutil@tempdima}{0pt}}{\pgfpoint{\pgfutil@tempdima}{\pgfutil@tempdima}}%
+            \pgfpathrectangle{\pgfpoint{\wd0-\pgfutil@tempdima}{\ht0-\pgfutil@tempdima}}{\pgfpoint{\pgfutil@tempdima}{\pgfutil@tempdima}}%
+            \pgfusepath{fill}%
+            \pgfpathmoveto{\pgfpoint{0pt}{\pgfutil@tempdima}}
+            \pgfpathcurveto{\pgfpoint{0pt}{0.555\pgfutil@tempdima}}{\pgfpoint{.555\pgfutil@tempdima}{0pt}}{\pgfpoint{\pgfutil@tempdima}{0pt}}
+            \pgfpathlineto{\pgfpoint{\wd0-\pgfutil@tempdima}{0pt}}
+            \pgfpathcurveto{\pgfpoint{\wd0-.555\pgfutil@tempdima}{0pt}}{\pgfpoint{\wd0}{.555\pgfutil@tempdima}}{\pgfpoint{\wd0}{\pgfutil@tempdima}}
+            \pgfpathlineto{\pgfpoint{\wd0}{\ht0-\pgfutil@tempdima}}
+            \pgfpathcurveto{\pgfpoint{\wd0}{\ht0-.555\pgfutil@tempdima}}{\pgfpoint{\wd0-.555\pgfutil@tempdima}{\ht0}}{\pgfpoint{\wd0-\pgfutil@tempdima}{\ht0}}
+            \pgfpathlineto{\pgfpoint{\pgfutil@tempdima}{\ht0}}
+            \pgfpathcurveto{\pgfpoint{.555\pgfutil@tempdima}{\ht0}}{\pgfpoint{0pt}{\ht0-.555\pgfutil@tempdima}}{\pgfpoint{0pt}{\ht0-\pgfutil@tempdima}}
+            \pgfpathclose
+            \pgfusepath{clip}
+            \color{white}
+            \pgfpathrectangle{\pgfpointorigin}{\pgfpoint{\wd0}{\ht0}}
+            \pgfusepath{fill}
+          }
+        \fi%
+        \ht0=0pt%
+        \wd0=0pt%
+        \dp0=0pt%
+        \pgfsys@hbox0%
+        \endpgfscope%
+      \pgfsys@endscope%
+    \fi
+    \ifnum\pgf@cpn<\csname pgf@lpageson@\the\pgf@cppn\endcsname\relax%
+      \advance \pgf@cpn by 1\relax%  
+    \repeat%
+    \pgfsys@endpicture%
+    }}%
+}
+
+
+\def\pgfpages@shipoutshipoutbox{%
+  \begingroup
+    \let \protect \noexpand
+    \@resetactivechars
+    \global\let\@@if@newlist\if@newlist
+    \global\@newlistfalse
+    \@parboxrestore%
+    \pgfpages@originalshipout%
+    \vbox{\hbox{%
+      \pgfsetupphysicalpagesizes%
+      \hskip-1in%
+      \vbox to \pgfphysicalheight{%
+        \vss\box\pgfpages@shipoutbox%
+        \vskip1in%
+      }}%
+      \pgfsetupphysicalpagesizes%
+    }%
+  \endgroup%
+}
+
+\def\pgfpages@performcopying{
+  \pgf@clpn=1\relax% copy first
+  \loop%
+    \expandafter\ifx\csname pgfpages@lp@\the\pgf@clpn @copy\endcsname\relax
+    \else%
+      \edef\pgf@temp{\noexpand\global\noexpand\setbox\csname pgfpages@box@%
+        \the\pgf@clpn\endcsname=\noexpand\copy\csname pgfpages@box@\csname
+        pgfpages@lp@\the\pgf@clpn @copy\endcsname\endcsname}%
+      \pgf@temp%
+    \fi%
+  \ifnum\pgf@clpn<\pgf@logicalpages%
+    \advance \pgf@clpn by 1\relax%  
+  \repeat%
+  \pgf@clpn=1\relax% then void
+  \loop%
+    \expandafter\ifx\csname pgfpages@lp@\the\pgf@clpn @copy\endcsname\relax
+      \expandafter\global\expandafter\setbox\csname pgfpages@box@\the\pgf@clpn\endcsname=\box\voidb@x%
+    \else%
+    \fi%
+  \ifnum\pgf@clpn<\pgf@logicalpages%
+    \advance \pgf@clpn by 1\relax%  
+  \repeat%
+}
+
+
+
+% Save original shipout commands
+%
+% Example:
+%
+% \pgfhookintoshipout
+
+\newcommand\pgfhookintoshipout{
+  \ifx\CROP@shipout\undefined
+  \let\pgfpages@originalshipout=\shipout
+  \let\shipout=\pgfpages@interceptshipout
+  \else
+    \let\pgfpages@originalshipout=\CROP@shipout
+    \let\CROP@shipout=\pgfpages@interceptshipout
+  \fi
+}
+
+\def\pgfpages@interceptshipout{%
+  \ifnum\pgf@shipoutnextto>0\relax
+    \def\pgf@next{%
+      \expandafter\global\expandafter\setbox\csname pgfpages@box@\the\pgf@shipoutnextto\endcsname=\box\voidb@x%
+      \afterassignment\pgfpages@shipouttestnext%
+      \pgfpagesshipoutlogicalpage{\the\pgf@shipoutnextto}%
+    }%
+  \else%
+    \ifpgf@holdingphysicalpage% shipout physical page now
+      {\pgfshipoutphysicalpage}%
+    \fi%    
+    \ifnum\pgf@logicalpages=0\relax
+      \def\pgf@next{\pgfpages@originalshipout}%
+    \else%
+      \def\pgf@next{%
+        \expandafter\global\expandafter\setbox\csname pgfpages@box@\the\pgf@currentshipout\endcsname=\box\voidb@x%
+        \afterassignment\pgfpages@shipouttest%
+        \pgfpagesshipoutlogicalpage{\the\pgf@currentshipout}%
+      }%
+    \fi%
+  \fi%
+  \pgf@next%  
+}
+
+\def\pgfpages@shipouttest{%
+  \ifvoid\csname pgfpages@box@\the\pgf@currentshipout\endcsname\relax%
+    \aftergroup\pgfpages@preparenextshipout%
+  \else%
+    \pgfpages@preparenextshipout%
+  \fi%
+}
+
+\def\pgfpages@shipouttestnext{%
+  \ifvoid\csname pgfpages@box@\the\pgf@shipoutnextto\endcsname\relax%
+    \aftergroup\pgfpages@preparenextshipout%
+  \else%
+    \pgfpages@preparenextshipout%
+  \fi%
+}
+ 
+\def\pgfpages@preparenextshipout{%
+  \ifnum\pgf@shipoutnextto=0\relax%
+    \global\advance\pgf@currentshipout by 1\relax%
+  \else%
+    \global\pgf@shipoutnextto=0\relax%
+  \fi%
+  \ifnum\pgf@currentshipout>\pgf@lastshipout\relax%
+    \global\pgf@currentshipout=\pgf@firstshipout\relax%
+    \global\pgf@holdingphysicalpagetrue%
+  \fi%
+}
+
+
+
+% Shipout a logical page
+%
+% #1 = logical page number
+%
+% The command should be followed by a box. This box will become the
+% contents of the logical page.
+%
+% Example:
+%
+% \pgfpagesshipoutlogicalpage{0}\vbox{Hi!}
+
+\newcommand\pgfpagesshipoutlogicalpage[1]{%
+  \global\pgfphysicalpageemptyfalse%
+  \expandafter\global\expandafter\setbox\csname pgfpages@box@#1\endcsname=}
+
+
+
+% Finish current page and shipout next page to a specific logical page.
+%
+% #1 = logical page number
+%
+% When the current page has been typset, it will be become the given
+% logical page. This command ``interrupts'' the normal order of
+% logical pages.
+%
+% Example:
+%
+% \pgfpagesuselayout{two screens with optional second}
+%
+% Text for main page.\clearpage
+%
+% \pgfpagescurrentpagewillbelogicalpage{2}
+%
+% Text that goes to second page
+%
+% \clearpage
+%
+% Text for main page.
+
+\newcommand\pgfpagescurrentpagewillbelogicalpage[1]{%
+  \global\pgf@shipoutnextto=#1\relax%
+}
+
+
+% Setup the physical page sizes
+%
+% Example:
+%
+% \pgfsetupphysicalpagesizes
+
+\newcommand\pgfsetupphysicalpagesizes{%
+  \pgfsys@global@papersize{\the\pgfphysicalwidth}{\the\pgfphysicalheight}%
+}
+
+
+%
+% Start/End setup
+%
+\pgfhookintoshipout
+
+\AtEndDocument
+{
+  \clearpage
+  \ifpgfphysicalpageempty
+  \else
+    \pgfshipoutphysicalpage
+  \fi
+}
+


### PR DESCRIPTION
Added demo presentation that uses my style.
I have tried to create quite a generic approach. This style also contains lots of definitions. Features:
- Contains a navigation bar, using `Hannover` theme.
- Redefinition of the `\note` command: Notes are automatically typeset at the same y-position as their text. This is something very useful as soon as [#58](https://github.com/dannyedel/dspdfviewer/issues/58) is fixed.
- Notes can contain hyperlinks. Although PGF manual says it is not possible to maintain hyperlink functionality with `pgfpages`, I have found a way (for this special layout; any differing page layout [notes not on the right side] would need special treatment) to fix this.
- `peek`-Environment which allows to show the contents of the next slide instead of notes. For this, I have used the `pgfmorepages` package from [TeX-SX launchpad](http://bazaar.launchpad.net/~tex-sx/tex-sx/development/files) and portions of [this SO post](http://tex.stackexchange.com/a/60628). However, I have patched the `pgfmorepages` (which is based on an older version of PGF) so that hyperlinks aren't broken any more.
- Fixed a bug in beamer which will produce endless warnings as soon as notes are enabled because of duplicated hypertargets.
- Navigation bar entries can be indented properly if they contain enumeration-like characters and are more than one line long (in the example, `§1 This is a long text` would be adjusted that the second line starts behind `§1`).
- Section-end marker defined which adds a symbol to the bottom right of the notes page to indicate that a section is now over (insert manually, with customizable text).
- Adjustable line spacing in content and notes, which will not affect the navigation.
- Notes can be switched on or of via one simple definition.
